### PR TITLE
Added sliceId Ref validation feature + unit tests

### DIFF
--- a/src/example.ts
+++ b/src/example.ts
@@ -5,7 +5,7 @@
 // found in the LICENSE file in the root of this package.
 
 import { hip } from '@rljson/hash';
-import { exampleJsonObject } from '@rljson/json';
+import { exampleJsonObject, Json } from '@rljson/json';
 
 import { BuffetsTable } from './content/buffet.ts';
 import { Cake, CakesTable } from './content/cake.ts';
@@ -157,6 +157,26 @@ export class Example {
         },
       };
     },
+    singleSliceIdRef: (): Rljson => {
+      return {
+        exampleSliceId: {
+          _type: 'sliceIds',
+          _data: [
+            {
+              add: ['id0', 'id1'],
+            },
+          ],
+        } as SliceIdsTable,
+        exampleComponent: {
+          _type: 'components',
+          _data: [
+            {
+              exampleSliceId: 'id0',
+            },
+          ],
+        } as ComponentsTable<Json>,
+      };
+    },
     complete: (): Rljson => {
       const sliceIds = hip<SliceIdsTable>({
         _type: 'sliceIds',
@@ -299,6 +319,40 @@ export class Example {
               },
             ],
           },
+        };
+      },
+
+      missingSliceId: (): Rljson => {
+        return {
+          exampleSliceId: {
+            _type: 'sliceIds',
+            _data: [
+              {
+                add: ['id0', 'id1'],
+              },
+            ],
+          } as SliceIdsTable,
+          exampleComponent: {
+            _type: 'components',
+            _data: [
+              {
+                exampleSliceId: 'id2',
+              },
+            ],
+          } as ComponentsTable<Json>,
+        };
+      },
+
+      missingSliceIdTable: (): Rljson => {
+        return {
+          exampleComponent: {
+            _type: 'components',
+            _data: [
+              {
+                exampleSliceId: 'id0',
+              },
+            ],
+          } as ComponentsTable<Json>,
         };
       },
     },

--- a/src/validate/base-validator.ts
+++ b/src/validate/base-validator.ts
@@ -115,6 +115,7 @@ class _BaseValidator {
 
       // Check references
       () => this._refsNotFound(),
+      () => this._sliceIdRefsNotFound(),
 
       // Check layers
       () => this._layerBasesNotFound(),
@@ -661,6 +662,65 @@ class _BaseValidator {
       this.errors.refsNotFound = {
         error: 'Broken references',
         missingRefs: missingRefs,
+      };
+    }
+  }
+
+  // ...........................................................................
+  private _sliceIdRefsNotFound(): void {
+    // Define a result object
+    const missingSliceIdRefs: {
+      error: string;
+      sourceTable: string;
+      targetTable: string;
+      targetSliceId: string;
+    }[] = [];
+
+    // Iterate all tables
+    iterateTablesSync(this.rljson, (tableKey, table) => {
+      // Iterate all items in the table
+      const tableData = table._data as Json[];
+      for (const item of tableData) {
+        for (const key of Object.keys(item)) {
+          // If item is a reference
+          if (key.endsWith('SliceId')) {
+            const targetSliceId = item[key] as string;
+
+            // If table is not found, write an error and continue
+            if (this.tableKeys.indexOf(key) === -1) {
+              missingSliceIdRefs.push({
+                sourceTable: tableKey,
+                targetSliceId: targetSliceId,
+                targetTable: key,
+                error: `Target table "${targetSliceId}" not found.`,
+              });
+              continue;
+            }
+
+            // If table is found, find the item in the target table
+            const targetSliceIdsTable = this.rljson[key];
+            const targetSliceIds = targetSliceIdsTable._data.flatMap((d) => [
+              ...d.add,
+              ...(d.remove ?? []),
+            ]);
+            // If referenced item is not found, write an error
+            if (targetSliceIds.indexOf(targetSliceId) === -1) {
+              missingSliceIdRefs.push({
+                sourceTable: tableKey,
+                targetSliceId: targetSliceId,
+                targetTable: key,
+                error: `Table "${key}" has no sliceId "${targetSliceId}"`,
+              });
+            }
+          }
+        }
+      }
+    });
+
+    if (missingSliceIdRefs.length > 0) {
+      this.errors.refsNotFound = {
+        error: 'Broken references',
+        missingRefs: missingSliceIdRefs,
       };
     }
   }

--- a/test/validate/base-validator.spec.ts
+++ b/test/validate/base-validator.spec.ts
@@ -883,6 +883,47 @@ describe('BaseValidator', async () => {
         });
       });
     });
+    describe('sliceIdRefsNotFound', () => {
+      it('returns no errors when all sliceIdRefs are found', () => {
+        expect(validate(Example.ok.singleSliceIdRef())).toEqual({
+          hasErrors: false,
+        });
+      });
+
+      it('returns an error when a sliceId reference table is not found', () => {
+        expect(validate(Example.broken.base.missingSliceIdTable())).toEqual({
+          refsNotFound: {
+            error: 'Broken references',
+            missingRefs: [
+              {
+                error: 'Target table "id0" not found.',
+                sourceTable: 'exampleComponent',
+                targetSliceId: 'id0',
+                targetTable: 'exampleSliceId',
+              },
+            ],
+          },
+          hasErrors: true,
+        });
+      });
+
+      it('returns an error when a ref is not found', () => {
+        expect(validate(Example.broken.base.missingSliceId())).toEqual({
+          refsNotFound: {
+            error: 'Broken references',
+            missingRefs: [
+              {
+                error: 'Table "exampleSliceId" has no sliceId "id2"',
+                sourceTable: 'exampleComponent',
+                targetSliceId: 'id2',
+                targetTable: 'exampleSliceId',
+              },
+            ],
+          },
+          hasErrors: true,
+        });
+      });
+    });
   });
 
   describe('layer errors', () => {


### PR DESCRIPTION
Added feature + validation + unit tests, that sliceIds can be referenced directly through other tables in RLJSON like:
`{
    exampleSliceId: {
      _type: 'sliceIds',
      _data: [
        {
          add: ['id0', 'id1'],
        },
      ],
    } as SliceIdsTable,
    exampleComponent: {
      _type: 'components',
      _data: [
        {
          exampleSliceId: 'id0',
        },
      ],
    } as ComponentsTable<Json>,
  }`